### PR TITLE
implement place rename method

### DIFF
--- a/src/components/PlaceModal.tsx
+++ b/src/components/PlaceModal.tsx
@@ -1,0 +1,86 @@
+import { Box, Button, Grid, Modal, TextField, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { Place } from "../hooks/usePlace";
+
+const modalStyle = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "80%",
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
+
+export type ModalProps = {
+  //add after
+  modalOpen: boolean;
+  handleModalClose: () => void;
+  targetPlace: null | Place;
+  renamePlace: (id: string, name: string) => void;
+};
+
+const PlaceModal: React.FC<ModalProps> = (props) => {
+  const [inputPlaceRename, setInputPlaceRename] = useState("");
+  const handleInputPlaceRename = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setInputPlaceRename(event.target.value);
+  };
+
+  useEffect(() => {
+    setInputPlaceRename(props.targetPlace?.name ?? "");
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.modalOpen]);
+
+  return (
+    <Modal
+      open={props.modalOpen}
+      onClose={props.handleModalClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box sx={modalStyle}>
+        <Grid
+          container
+          direction="column"
+          justifyContent="center"
+          alignItems="center"
+          spacing={2}
+        >
+          <Grid item xs="auto">
+            <Typography id="modal-modal-title" variant="h6" component="h2">
+              場所名を編集
+            </Typography>
+          </Grid>
+          <Grid item xs="auto">
+            <TextField
+              id="outlined-basic"
+              variant="outlined"
+              onChange={handleInputPlaceRename}
+              value={inputPlaceRename}
+            />
+          </Grid>
+          <Grid item xs="auto">
+            <Button
+              variant="contained"
+              onClick={() => {
+                if (props.targetPlace) {
+                  props.renamePlace(props.targetPlace.id, inputPlaceRename);
+                }
+                props.handleModalClose();
+              }}
+            >
+              変更を保存
+            </Button>
+          </Grid>
+        </Grid>
+      </Box>
+    </Modal>
+  );
+};
+
+export default PlaceModal;

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -1,32 +1,16 @@
 import React, { useState } from "react";
 import {
-  Box,
-  Button,
-  Grid,
   IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
-  Modal,
   TextField,
-  Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ClearIcon from "@mui/icons-material/Clear";
 import { Place, usePlace } from "../hooks/usePlace";
-
-const modalStyle = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: "80%",
-  bgcolor: "background.paper",
-  border: "2px solid #000",
-  boxShadow: 24,
-  p: 4,
-};
+import PlaceModal from "../components/PlaceModal";
 
 const PlacePage = () => {
   const { placeList, addPlace, deletePlace, renamePlace } = usePlace();
@@ -39,18 +23,11 @@ const PlacePage = () => {
   const [modalOpen, setModalOpen] = React.useState(false);
   const handleModalOpen = (place: Place) => {
     setTargetPlace(place);
-    setInputPlaceRename(place.name);
     setModalOpen(true);
   };
   const handleModalClose = () => setModalOpen(false);
 
   //rename処理
-  const [inputPlaceRename, setInputPlaceRename] = useState("");
-  const handleInputPlaceRename = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setInputPlaceRename(event.target.value);
-  };
   const [targetPlace, setTargetPlace] = useState<Place | null>(null);
 
   return (
@@ -95,51 +72,12 @@ const PlacePage = () => {
           })}
         </List>
       </div>
-      <div>
-        <Modal
-          open={modalOpen}
-          onClose={handleModalClose}
-          aria-labelledby="modal-modal-title"
-          aria-describedby="modal-modal-description"
-        >
-          <Box sx={modalStyle}>
-            <Grid
-              container
-              direction="column"
-              justifyContent="center"
-              alignItems="center"
-              spacing={2}
-            >
-              <Grid item xs="auto">
-                <Typography id="modal-modal-title" variant="h6" component="h2">
-                  場所名を編集
-                </Typography>
-              </Grid>
-              <Grid item xs="auto">
-                <TextField
-                  id="outlined-basic"
-                  variant="outlined"
-                  onChange={handleInputPlaceRename}
-                  value={inputPlaceRename}
-                />
-              </Grid>
-              <Grid item xs="auto">
-                <Button
-                  variant="contained"
-                  onClick={() => {
-                    if (targetPlace) {
-                      renamePlace(targetPlace.id, inputPlaceRename);
-                    }
-                    setModalOpen(false);
-                  }}
-                >
-                  変更を保存
-                </Button>
-              </Grid>
-            </Grid>
-          </Box>
-        </Modal>
-      </div>
+      <PlaceModal
+        modalOpen={modalOpen}
+        handleModalClose={handleModalClose}
+        targetPlace={targetPlace}
+        renamePlace={renamePlace}
+      />
     </div>
   );
 };

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -21,7 +21,7 @@ const modalStyle = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  width: 400,
+  width: "80%",
   bgcolor: "background.paper",
   border: "2px solid #000",
   boxShadow: 24,
@@ -127,9 +127,9 @@ const PlacePage = () => {
                 <Button
                   variant="contained"
                   onClick={() => {
-                    //if文の書き方これであってますか？
-                    targetPlace &&
+                    if (targetPlace) {
                       renamePlace(targetPlace.id, inputPlaceRename);
+                    }
                     setModalOpen(false);
                   }}
                 >

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -1,22 +1,58 @@
 import React, { useState } from "react";
 import {
+  Box,
+  Button,
+  Grid,
   IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
+  Modal,
+  Stack,
   TextField,
+  Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ClearIcon from "@mui/icons-material/Clear";
-import { usePlace } from "../hooks/usePlace";
+import { Place, usePlace } from "../hooks/usePlace";
+
+const modalStyle = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
 
 const PlacePage = () => {
-  const { placeList, addPlace, deletePlace } = usePlace();
+  const { placeList, addPlace, deletePlace, renamePlace } = usePlace();
   const [inputPlace, setInputPlace] = useState("");
   const handlePlaceInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputPlace(event.target.value);
   };
+
+  // modal処理
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const handleModalOpen = (place: Place) => {
+    setTargetPlace(place);
+    setInputPlaceRename(place.name);
+    setModalOpen(true);
+  };
+  const handleModalClose = () => setModalOpen(false);
+
+  //rename処理
+  const [inputPlaceRename, setInputPlaceRename] = useState("");
+  const handleInputPlaceRename = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setInputPlaceRename(event.target.value);
+  };
+  const [targetPlace, setTargetPlace] = useState<Place | null>(null);
 
   return (
     <div>
@@ -52,13 +88,58 @@ const PlacePage = () => {
                   </IconButton>
                 }
               >
-                <ListItemButton>
+                <ListItemButton onClick={() => handleModalOpen(place)}>
                   <ListItemText primary={place.name} />
                 </ListItemButton>
               </ListItem>
             );
           })}
         </List>
+      </div>
+      <div>
+        <Modal
+          open={modalOpen}
+          onClose={handleModalClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Box sx={modalStyle}>
+            <Grid
+              container
+              direction="column"
+              justifyContent="center"
+              alignItems="center"
+              spacing={2}
+            >
+              <Grid item xs="auto">
+                <Typography id="modal-modal-title" variant="h6" component="h2">
+                  場所名を編集
+                </Typography>
+              </Grid>
+              <Grid item xs="auto">
+                <TextField
+                  id="outlined-basic"
+                  variant="outlined"
+                  onChange={handleInputPlaceRename}
+                  value={inputPlaceRename}
+                />
+              </Grid>
+              <Grid item xs="auto">
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    //if文の書き方これであってますか？
+                    targetPlace &&
+                      renamePlace(targetPlace.id, inputPlaceRename);
+                    setModalOpen(false);
+                  }}
+                >
+                  変更を保存
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+        </Modal>
       </div>
     </div>
   );

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -9,7 +9,6 @@ import {
   ListItemButton,
   ListItemText,
   Modal,
-  Stack,
   TextField,
   Typography,
 } from "@mui/material";


### PR DESCRIPTION
#30 

## やったこと（ユーザ目線）
`/place`にて、一度登録した場所の名前を変更できるようにした
![スクリーンショット 2022-09-05 9 47 34](https://user-images.githubusercontent.com/79315807/188340506-605d681e-ce49-4de5-ace5-c30fe9d4e993.png)

## やったこと（実装）
`PlacePage.tsx`に以下を実装
- modal
  -  開閉処理
  - 変更フォーム
- 場所名変更処理
  - モーダル開閉時に取得した`targetPlace`に対して変更フォームの入力内容を適用（`usePlace`の`renamePlace`を利用）

## 相談したいこと
### modalの置き方について
- 現在の実装ではmodalを全体で一つだけ用意して、開閉時に別のuseStateで対象となるPlaceの情報を保持していますが、この実装で問題ないですか？

### modalの分割について
- modal部分の記述が多くなってしまったので分割した方がいい？

## メモ
### レスポンシブ対応
- modalのcssをabsoluteで指定しているのでスマホサイズにするとboxではなく帯みたいな見た目になる（boxの左右端が見切れる）
