### PR TITLE
configPage＆useConfigの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@fontsource/roboto": "^4.5.8",
     "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.10.3",
+    "@mui/x-date-pickers": "^5.0.0",
+    "dayjs": "^1.11.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0"

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -8,7 +8,6 @@ export type configTime = {
 };
 
 export const useConfig = () => {
-  //pushtimeの型の付け方どうする問題
   const [pushTime, setPushTime] = useState<configTime>({
     hours: 21,
     minutes: 0,

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -2,16 +2,20 @@
 import { useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 
-export type Config = {
-  pushTime: Dayjs;
+export type configTime = {
+  hours: number;
+  minutes: number;
 };
 
 export const useConfig = () => {
   //pushtimeの型の付け方どうする問題
-  const [pushTime, setPushTime] = useState<Dayjs | null>(dayjs());
+  const [pushTime, setPushTime] = useState<configTime>({
+    hours: 21,
+    minutes: 0,
+  });
 
-  const updatePushTime = (time: Dayjs | null) => {
-    setPushTime(time);
+  const updatePushTime = (time: Dayjs) => {
+    setPushTime({ hours: time.hour(), minutes: time.minute() });
   };
 
   return {

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,0 +1,21 @@
+import { Place } from "@mui/icons-material";
+import { useState } from "react";
+import dayjs, { Dayjs } from "dayjs";
+
+export type Config = {
+  pushTime: Dayjs;
+};
+
+export const useConfig = () => {
+  //pushtimeの型の付け方どうする問題
+  const [pushTime, setPushTime] = useState<Dayjs | null>(dayjs());
+
+  const updatePushTime = (time: Dayjs | null) => {
+    setPushTime(time);
+  };
+
+  return {
+    pushTime,
+    updatePushTime,
+  };
+};

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,4 +1,4 @@
-import { Place } from "@mui/icons-material";
+// import { Place } from "@mui/icons-material";
 import { useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 // import { Place } from "@mui/icons-material";
 import { useState } from "react";
-import dayjs, { Dayjs } from "dayjs";
+import { Dayjs } from "dayjs";
 
 export type configTime = {
   hours: number;

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
 import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { Dayjs } from "dayjs";
 import { useConfig } from "../hooks/useConfig";
 // import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -3,10 +3,11 @@ import { Button, Stack, TextField, Typography } from "@mui/material";
 import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Dayjs } from "dayjs";
+import { useConfig } from "../hooks/useConfig";
 // import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 const ConfigPage = () => {
-  const [value, setValue] = React.useState<Dayjs | null>(null);
+  const { pushTime, updatePushTime } = useConfig();
   return (
     <Stack spacing={2}>
       <Stack direction="row" spacing={2} justifyContent="space-between">
@@ -18,9 +19,9 @@ const ConfigPage = () => {
           sx={{ width: "right" }}
         >
           <TimePicker
-            value={value}
+            value={pushTime}
             onChange={(newValue) => {
-              setValue(newValue);
+              updatePushTime(newValue);
             }}
             renderInput={(params) => <TextField {...params} />}
           />

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -4,7 +4,6 @@ import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { useConfig } from "../hooks/useConfig";
 import dayjs, { Dayjs } from "dayjs";
-// import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 const ConfigPage = () => {
   const { pushTime, updatePushTime } = useConfig();

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -11,6 +11,7 @@ const ConfigPage = () => {
   const [timePicker, setTimePicker] = useState<Dayjs>(dayjs());
   useEffect(() => {
     setTimePicker(dayjs().hour(pushTime.hours).minute(pushTime.minutes));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
     <Stack spacing={2}>

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography } from "@mui/material";
 import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Dayjs } from "dayjs";
@@ -8,12 +8,15 @@ import { Dayjs } from "dayjs";
 const ConfigPage = () => {
   const [value, setValue] = React.useState<Dayjs | null>(null);
   return (
-    <div>
-      <div>
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2} justifyContent="space-between">
         <Typography variant="h4" component="p" gutterBottom>
           通知時間
         </Typography>
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <LocalizationProvider
+          dateAdapter={AdapterDayjs}
+          sx={{ width: "right" }}
+        >
           <TimePicker
             value={value}
             onChange={(newValue) => {
@@ -22,11 +25,12 @@ const ConfigPage = () => {
             renderInput={(params) => <TextField {...params} />}
           />
         </LocalizationProvider>
-      </div>
+      </Stack>
+
       <div>
         <Button variant="contained">設定を保存</Button>
       </div>
-    </div>
+    </Stack>
   );
 };
 

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -1,12 +1,17 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
 import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { useConfig } from "../hooks/useConfig";
+import dayjs, { Dayjs } from "dayjs";
 // import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 const ConfigPage = () => {
   const { pushTime, updatePushTime } = useConfig();
+  const [timePicker, setTimePicker] = useState<Dayjs>(dayjs());
+  useEffect(() => {
+    setTimePicker(dayjs().hour(pushTime.hours).minute(pushTime.minutes));
+  }, []);
   return (
     <Stack spacing={2}>
       <Stack direction="row" spacing={2} justifyContent="space-between">
@@ -18,9 +23,11 @@ const ConfigPage = () => {
           sx={{ width: "right" }}
         >
           <TimePicker
-            value={pushTime}
+            value={timePicker}
             onChange={(newValue) => {
-              updatePushTime(newValue);
+              if (newValue) {
+                setTimePicker(newValue);
+              }
             }}
             renderInput={(params) => <TextField {...params} />}
           />
@@ -28,7 +35,14 @@ const ConfigPage = () => {
       </Stack>
 
       <div>
-        <Button variant="contained">設定を保存</Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            updatePushTime(timePicker);
+          }}
+        >
+          設定を保存
+        </Button>
       </div>
     </Stack>
   );

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -1,16 +1,27 @@
 import React from "react";
 import { Button, TextField, Typography } from "@mui/material";
-// import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
+import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { Dayjs } from "dayjs";
 // import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 const ConfigPage = () => {
+  const [value, setValue] = React.useState<Dayjs | null>(null);
   return (
     <div>
       <div>
         <Typography variant="h4" component="p" gutterBottom>
           通知時間
         </Typography>
-        <TextField id="standard-basic" placeholder="09:00" variant="standard" />
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <TimePicker
+            value={value}
+            onChange={(newValue) => {
+              setValue(newValue);
+            }}
+            renderInput={(params) => <TextField {...params} />}
+          />
+        </LocalizationProvider>
       </div>
       <div>
         <Button variant="contained">設定を保存</Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,6 +247,39 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
+"@date-io/core@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.15.0.tgz#8133860c8ce163b8d0cca3c1caed8d5d1fbfb14e"
+  integrity sha512-3CRvQUEK7aF87NUOwcTtmJ2Rc1kN0D4jFQUfRoanuAnE4o5HzHx4E2YenjaKjSPWeZYiWG6ZhDomx5hp1AaCJA==
+
+"@date-io/date-fns@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.15.0.tgz#2541144f4fc40365efd7d0b7affa5d77dbe59102"
+  integrity sha512-hkVeLm0jijHS2F9YVQcf0LSlD55w9xPvvIfuxDE0XWNXOTcRAAhqw2aqOxyeGbmHxc5U4HqyPZaqs9tfeTsomQ==
+  dependencies:
+    "@date-io/core" "^2.15.0"
+
+"@date-io/dayjs@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.15.0.tgz#474a42586e67be1108a6f68b0a2e5e6088620fb6"
+  integrity sha512-wgYzwaXr9KxkHNYxrOb1t8fYLfAdjIf0Q86qdVCwANObcvyGcPBm0uFtpPK7ApeE4DJUlbuG0IX75TtO+uITwQ==
+  dependencies:
+    "@date-io/core" "^2.15.0"
+
+"@date-io/luxon@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.15.0.tgz#ad5bea9c46b46230bd780dc91413f31d1967830f"
+  integrity sha512-CxTRCo5AM96ainnYaTpe1NS9GiA78SIgXBScgeAresCS20AvMcOd5XKerDj+y/KLhbSQbU6WUDqG9QcsrImXyQ==
+  dependencies:
+    "@date-io/core" "^2.15.0"
+
+"@date-io/moment@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.15.0.tgz#d6c2c88b58534d0c44644abcfefc27cb32182dd8"
+  integrity sha512-AcYBjl3EnEGsByaM5ir644CKbhgJsgc1iWFa9EXfdb4fQexxOC8oCdPAurK2ZDTwg62odyyKa/05YE7ElYh5ag==
+  dependencies:
+    "@date-io/core" "^2.15.0"
+
 "@emotion/babel-plugin@^11.10.0":
   version "11.10.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz#879db80ba622b3f6076917a1e6f648b1c7d008c7"
@@ -526,7 +559,7 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.0.tgz#91380c2d42420f51f404120f7a9270eadd6f5c23"
   integrity sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==
 
-"@mui/utils@^5.10.3":
+"@mui/utils@^5.10.3", "@mui/utils@^5.9.3":
   version "5.10.3"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.10.3.tgz#ce2a96f31de2a5e717f507b5383dbabbddbc4dfc"
   integrity sha512-4jXMDPfx6bpMVuheLaOpKTjpzw39ogAZLeaLj5+RJec3E37/hAZMYjURfblLfTWMMoGoqkY03mNsZaEwNobBow==
@@ -536,6 +569,24 @@
     "@types/react-is" "^16.7.1 || ^17.0.0"
     prop-types "^15.8.1"
     react-is "^18.2.0"
+
+"@mui/x-date-pickers@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.0.tgz#e8b1dfe37e0ec611b2856e91984b76ded59c7f3c"
+  integrity sha512-LcWJYFC/SdYbu0JSz6pgQcCh/cvllyoAqfpqf6iTex7jMSEk8i008pCntyrEVVcjGrx0fakDduSJthlnf0xNxQ==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@date-io/core" "^2.15.0"
+    "@date-io/date-fns" "^2.15.0"
+    "@date-io/dayjs" "^2.15.0"
+    "@date-io/luxon" "^2.15.0"
+    "@date-io/moment" "^2.15.0"
+    "@mui/utils" "^5.9.3"
+    "@types/react-transition-group" "^4.4.5"
+    clsx "^1.2.1"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.5"
+    rifm "^0.12.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -916,6 +967,11 @@ csstype@^3.0.2, csstype@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
+dayjs@^1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -1995,7 +2051,7 @@ prettier@2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2115,6 +2171,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rifm@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.12.1.tgz#8fa77f45b7f1cda2a0068787ac821f0593967ac4"
+  integrity sha512-OGA1Bitg/dSJtI/c4dh90svzaUPt228kzFsUkJbtA2c964IqEAwWXeL9ZJi86xWv3j5SMqRvGULl7bA6cK0Bvg==
 
 rimraf@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
#17 #18 #34 
## やったこと
以下の二つにより、設定ページの通知時間をstateで拾えるようにした
- configpageの実装
- useconfigの実装

## 相談したいこと
- configの諸々設定は一つのdictにまとめたほうがいいか
  - まとめるとconfigpageで読み出した後、時間管理に別のstateを作る必要がある？
  - 今は通知時間をuseconfig内で一つのstateにしてます
- 保存ボタンの存在意義
  - 今の仕様だと設定画面で通知時間をいじるとuseconfigのstateを直で変更してしまうので保存ボタンを押す意味がない
  - stateは自動変更して保存ボタン押した時にDBとやり取りするとかが良いでしょうか