### PR TITLE
prevent empty input

### DIFF
--- a/src/components/PlaceModal.tsx
+++ b/src/components/PlaceModal.tsx
@@ -24,10 +24,16 @@ export type ModalProps = {
 
 const PlaceModal: React.FC<ModalProps> = (props) => {
   const [inputPlaceRename, setInputPlaceRename] = useState("");
+  const [buttonEnabled, setButtonEnabled] = useState(true);
   const handleInputPlaceRename = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setInputPlaceRename(event.target.value);
+    if (!event.target.value) {
+      setButtonEnabled(false);
+    } else {
+      setButtonEnabled(true);
+    }
   };
 
   useEffect(() => {
@@ -73,6 +79,7 @@ const PlaceModal: React.FC<ModalProps> = (props) => {
                 }
                 props.handleModalClose();
               }}
+              disabled={!buttonEnabled}
             >
               変更を保存
             </Button>

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -42,8 +42,10 @@ const PlacePage = () => {
         />
         <IconButton
           onClick={() => {
-            addPlace(inputPlace);
-            setInputPlace("");
+            if (inputPlace) {
+              addPlace(inputPlace);
+              setInputPlace("");
+            }
           }}
         >
           <AddIcon />


### PR DESCRIPTION
#33 

## やったこと
- 場所を追加する時、入力ボックスが空白の場合は＋ボタンを押しても動作しないようにした
- 場所名を変更するとき、空白の場合は変更保存ボタンが無効化されるようにした