### PR TITLE
6 timerpageのロジックを実装する

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@mui/material": "^5.10.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "react-timer-hook": "^3.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/src/components/OsojiTimer.tsx
+++ b/src/components/OsojiTimer.tsx
@@ -7,7 +7,7 @@ export type TimerProps = {
 };
 
 const OsojiTimer: React.FC<TimerProps> = (props) => {
-  const { seconds, minutes, isRunning, start, pause } = useTimer({
+  const { seconds, minutes, resume, isRunning, start, pause } = useTimer({
     expiryTimestamp: props.expiryTimeStamp,
     autoStart: false,
     onExpire: () => {
@@ -21,12 +21,11 @@ const OsojiTimer: React.FC<TimerProps> = (props) => {
       <Typography variant="h1" component="h2" gutterBottom>
         {minutes}:{("00" + seconds).slice(-2)}
       </Typography>
-      <div style={{ display: isOsojiCompleted ? "" : "none" }}>
+      {isOsojiCompleted ? (
         <Typography variant="h2" component="h2" gutterBottom>
           お掃除完了！
         </Typography>
-      </div>
-      <div style={{ display: isOsojiCompleted ? "none" : "" }}>
+      ) : (
         <div>
           <Button
             variant="contained"
@@ -43,13 +42,13 @@ const OsojiTimer: React.FC<TimerProps> = (props) => {
           </Button>
           <Button
             variant="contained"
-            onClick={start}
+            onClick={resume}
             disabled={isRunning || !isTimerStarted}
           >
             再開
           </Button>
         </div>
-      </div>
+      )}
     </>
   );
 };

--- a/src/components/OsojiTimer.tsx
+++ b/src/components/OsojiTimer.tsx
@@ -1,0 +1,57 @@
+import { Button, Typography } from "@mui/material";
+import React, { useState } from "react";
+import { useTimer } from "react-timer-hook";
+
+export type TimerProps = {
+  expiryTimeStamp: Date;
+};
+
+const OsojiTimer: React.FC<TimerProps> = (props) => {
+  const { seconds, minutes, isRunning, start, pause } = useTimer({
+    expiryTimestamp: props.expiryTimeStamp,
+    autoStart: false,
+    onExpire: () => {
+      setIsOsojiCompleted(true);
+    },
+  });
+  const [isTimerStarted, setIsTimerStarted] = useState(false);
+  const [isOsojiCompleted, setIsOsojiCompleted] = useState(false);
+  return (
+    <>
+      <Typography variant="h1" component="h2" gutterBottom>
+        {minutes}:{("00" + seconds).slice(-2)}
+      </Typography>
+      <div style={{ display: isOsojiCompleted ? "" : "none" }}>
+        <Typography variant="h2" component="h2" gutterBottom>
+          お掃除完了！
+        </Typography>
+      </div>
+      <div style={{ display: isOsojiCompleted ? "none" : "" }}>
+        <div>
+          <Button
+            variant="contained"
+            onClick={() => {
+              start();
+              setIsTimerStarted(true);
+            }}
+            disabled={isTimerStarted}
+          >
+            掃除を開始する
+          </Button>
+          <Button variant="contained" onClick={pause} disabled={!isRunning}>
+            一時停止
+          </Button>
+          <Button
+            variant="contained"
+            onClick={start}
+            disabled={isRunning || !isTimerStarted}
+          >
+            再開
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OsojiTimer;

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -1,6 +1,10 @@
-import { Button, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
+import React from "react";
+import OsojiTimer from "../components/OsojiTimer";
 
 const TimerPage = () => {
+  const timerTime = new Date();
+  timerTime.setSeconds(timerTime.getSeconds() + 30); // 10 minutes timer
   return (
     <div>
       <div>
@@ -8,17 +12,7 @@ const TimerPage = () => {
           床を掃除しよう！
         </Typography>
       </div>
-      <div>
-        <Typography variant="h1" component="h2" gutterBottom>
-          10:00
-        </Typography>
-        <div>
-          <Button variant="contained">掃除を開始する</Button>
-          <Button variant="contained" disabled>
-            掃除を完了する
-          </Button>
-        </div>
-      </div>
+      <OsojiTimer expiryTimeStamp={timerTime} />
     </div>
   );
 };

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -4,7 +4,7 @@ import OsojiTimer from "../components/OsojiTimer";
 
 const TimerPage = () => {
   const timerTime = new Date();
-  timerTime.setSeconds(timerTime.getSeconds() + 30); // 10 minutes timer
+  timerTime.setSeconds(timerTime.getSeconds() + 600); // 10 minutes timer
   return (
     <div>
       <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,11 @@ react-router@6.3.0:
   dependencies:
     history "^5.2.0"
 
+react-timer-hook@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-timer-hook/-/react-timer-hook-3.0.5.tgz#a8d930f99b180cd88da245965a26a17df3e7457b"
+  integrity sha512-n+98SdmYvui2ne3KyWb3Ldu4k0NYQa3g/VzW6VEIfZJ8GAk/jJsIY700M8Nd2vNSTj05c7wKyQfJBqZ0x7zfiA==
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
#6 
## やったこと（ユーザ目線）
- タイマーを実装(開始、一時停止、再開)
![スクリーンショット 2022-09-08 12 18 50](https://user-images.githubusercontent.com/79315807/189026535-10733817-b215-41eb-ad2a-b60b8a7d0136.png)
- タイマー終わると表示が変わる
![スクリーンショット 2022-09-08 12 19 59](https://user-images.githubusercontent.com/79315807/189026674-6299b1b4-b30a-43a0-887c-e64bc42ac1a3.png)


## やったこと（実装）
- timerpageからtimer部分を切り分け
- osojitimerコンポーネントを実装
  - react-timer-hookを使用

## 相談したいこと
- 掃除開始、停止、再開ボタンの表示方法
  - 現在は3つともデフォルトで表示されており、タイマー実行中かどうかなどによって押下できるボタンが変わる
