### PR TITLE
pushTimeの永続化&pushtimestateの切り出し

### DIFF
--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,6 +1,11 @@
 // import { Place } from "@mui/icons-material";
+import { atom, useRecoilState } from "recoil";
+import { recoilPersist } from "recoil-persist";
 import { useState } from "react";
 import { Dayjs } from "dayjs";
+import { usePushTime } from "../states/pushTimeState";
+
+const { persistAtom } = recoilPersist();
 
 export type configTime = {
   hours: number;
@@ -8,15 +13,10 @@ export type configTime = {
 };
 
 export const useConfig = () => {
-  const [pushTime, setPushTime] = useState<configTime>({
-    hours: 21,
-    minutes: 0,
-  });
-
+  const { pushTime, setPushTime } = usePushTime();
   const updatePushTime = (time: Dayjs) => {
     setPushTime({ hours: time.hour(), minutes: time.minute() });
   };
-
   return {
     pushTime,
     updatePushTime,

--- a/src/states/pushTimeState.ts
+++ b/src/states/pushTimeState.ts
@@ -1,0 +1,21 @@
+import { atom, useRecoilState } from "recoil";
+import { recoilPersist } from "recoil-persist";
+import { configTime } from "../hooks/useConfig";
+
+const { persistAtom } = recoilPersist();
+
+const initialPushTime: configTime = {
+  hours: 21,
+  minutes: 0,
+};
+
+const pushTimeState = atom({
+  key: "pushtime",
+  default: initialPushTime as configTime,
+  effects: [persistAtom],
+});
+
+export const usePushTime = () => {
+  const [pushTime, setPushTime] = useRecoilState(pushTimeState);
+  return { pushTime, setPushTime };
+};


### PR DESCRIPTION
#65 

- `pushTime`にrecoil &recoil-persistを導入し、リロード・ページ遷移時の値の保持に対応
- `usePushTime.ts`を作成し、pushTimeのstateを切り出し
  - 更新などは`useConfig.ts`で処理のまま