### PR TITLE
ログイン後リダイレクト前のurlに遷移

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,9 +1,21 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useFirebaseAuth } from "../hooks/useFirebaseAuth";
 import { Button } from "@mui/material";
+import { useEffect } from "react";
+import { useRecoilValue } from "recoil";
+import { authenticatedState } from "../provider/firebaseStore";
 
 const LoginPage = () => {
   const { signInAction, signOutAction } = useFirebaseAuth();
+  const navigate = useNavigate();
+  const authenticated = useRecoilValue(authenticatedState);
+  useEffect(() => {
+    const redirect_to_path = sessionStorage.getItem("url_redirected_from");
+    if (authenticated && redirect_to_path !== null) {
+      sessionStorage.removeItem("url_redirected_from");
+      navigate(redirect_to_path);
+    }
+  }, []);
 
   return (
     <>

--- a/src/router/RouterAuthenticateConfig.tsx
+++ b/src/router/RouterAuthenticateConfig.tsx
@@ -61,7 +61,13 @@ export const RouterAuthenticatedCheck = (props: Props) => {
 export const RouterHasAuthenticated = (props: Props) => {
   const { component } = props;
   const authenticated = useRecoilValue(authenticatedState);
-  // todo: redirect先をいい感じに変えたいので構成相談
-  if (!authenticated) return <NavigationPage redirect="/login" />;
+  // 現在のurlを取得
+  // 現状の仕様だと別のところから飛んだ後にloginでリロードをした場合最初に飛ぶ前のリンクに戻る
+  const path = useLocation();
+  if (!authenticated) {
+    // 未認証の場合はsessionStorageに現在のURLを入れた後に
+    sessionStorage.setItem("url_redirected_from", path.pathname);
+    return <NavigationPage redirect="/login" />;
+  }
   return <>{component}</>;
 };


### PR DESCRIPTION
ログイン後に最後に見ていたページに飛ぶ仕様に変更
やったこと
- `RouterHasAuthenticated`で未認証の場合にsessionStorageにURLを保存
- `LoginPage`にて最初に起動した際に認証済み＆sessionStorageに値があるか確認し、ある場合はそのページに遷移

現在の実装の問題点
- 場所登録ページからログインページに遷移し、そこでリロードをした場合などもログイン後場所登録ページに遷移しない（これはLoginPageはRouterHasAuthenticatedを通していないためおこる）
- `LoginPage`内で遷移処理を行なっているため、ログイン後繊維までに時間がかかる
  - 最初RouterHasAuthenticatedで認証済みとsessionStorageの確認および遷移を入れていたのですが、条件分岐まではうまく行くもののreturnする`<NavigationPage redirect={遷移先URL} />`がうまく動きませんでした...