### PR TITLE
タイマー終了後次のタイマーに遷移

### DIFF
--- a/src/components/OsojiTimer.tsx
+++ b/src/components/OsojiTimer.tsx
@@ -8,25 +8,40 @@ export type TimerProps = {
 };
 
 const OsojiTimer: React.FC<TimerProps> = (props) => {
-  const { seconds, minutes, resume, isRunning, start, pause } = useTimer({
-    expiryTimestamp: props.expiryTimeStamp,
-    autoStart: false,
-    onExpire: () => {
-      setIsOsojiCompleted(true);
-      props.handleFinishInfo();
-    },
-  });
+  const { seconds, minutes, resume, isRunning, restart, start, pause } =
+    useTimer({
+      expiryTimestamp: props.expiryTimeStamp,
+      autoStart: false,
+      onExpire: () => {
+        setIsOsojiCompleted(true);
+        props.handleFinishInfo();
+      },
+    });
   const [isTimerStarted, setIsTimerStarted] = useState(false);
   const [isOsojiCompleted, setIsOsojiCompleted] = useState(false);
+
+  const resetTimer = () => {
+    const time = new Date();
+    time.setSeconds(time.getSeconds() + 600);
+    restart(time, false);
+    setIsOsojiCompleted(false);
+    setIsTimerStarted(false);
+  };
+
   return (
     <>
       <Typography variant="h1" component="h2" gutterBottom>
         {minutes}:{("00" + seconds).slice(-2)}
       </Typography>
       {isOsojiCompleted ? (
-        <Typography variant="h2" component="h2" gutterBottom>
-          お掃除完了！
-        </Typography>
+        <>
+          <Typography variant="h2" component="h2" gutterBottom>
+            お掃除完了！
+          </Typography>
+          <Button variant="contained" onClick={resetTimer}>
+            次の場所を掃除する
+          </Button>
+        </>
       ) : (
         <div>
           <Button

--- a/src/components/OsojiTimer.tsx
+++ b/src/components/OsojiTimer.tsx
@@ -1,6 +1,7 @@
 import { Button, Typography } from "@mui/material";
 import React, { useState } from "react";
 import { useTimer } from "react-timer-hook";
+import { useConfig } from "../hooks/useConfig";
 
 export type TimerProps = {
   expiryTimeStamp: Date;
@@ -8,6 +9,7 @@ export type TimerProps = {
 };
 
 const OsojiTimer: React.FC<TimerProps> = (props) => {
+  const { cleanTime } = useConfig();
   const { seconds, minutes, resume, isRunning, restart, start, pause } =
     useTimer({
       expiryTimestamp: props.expiryTimeStamp,
@@ -22,7 +24,7 @@ const OsojiTimer: React.FC<TimerProps> = (props) => {
 
   const resetTimer = () => {
     const time = new Date();
-    time.setSeconds(time.getSeconds() + 600);
+    time.setSeconds(time.getSeconds() + cleanTime * 60);
     restart(time, false);
     setIsOsojiCompleted(false);
     setIsTimerStarted(false);


### PR DESCRIPTION
#76 
timerページでタイマーが終わった後、「次の場所を掃除する」というボタンが表示され、それを押すとタイマーが再起動する（開始はしない）
やったこと
- `OsojiTimer`に次の掃除を開始するボタンを追加
- 掃除開始ボタンを押すとTimerがrestartし、ボタンの表示の制御をしている`isTimerStarted`と`isOsojiCompleted`もページ遷移時の状態に戻る

思っていること
- タイマーをリスタートする時にタイムスタンプを引数に入れる必要がある→そもそも最初のページ移動時のタイマーのセットも全て`OsojiTimer`内でやった方が綺麗？現在は`TimerPage`で定義して引数としている
- 現在はタイマー終了後次の掃除場所が出てきてしまうが、次の掃除を開始するボタン押してからの方がいい？
- #77 と干渉しているため現在は再起動時の値を実数指定しているが、#77 をマージしたら`cleanTime`を参照するように変更する必要あり